### PR TITLE
libaccessom2.pc.in: should require datetime-fortran

### DIFF
--- a/libaccessom2.pc.in
+++ b/libaccessom2.pc.in
@@ -6,6 +6,6 @@ includedir="${prefix}/include"
 Name: libaccessom2
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires.private: datetime
+Requires.private: datetime-fortran
 Cflags: -I"${includedir}"
 Libs: -L"${libdir}" -laccessom2


### PR DESCRIPTION
* Thanks to Dougie Squire for noticing it.