### PR TITLE
Update libaccessom2.pc.in

### DIFF
--- a/libaccessom2.pc.in
+++ b/libaccessom2.pc.in
@@ -1,11 +1,11 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-libdir="${prefix}/lib"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
 includedir="${prefix}/include"
 
 Name: libaccessom2
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires.private: datetime-fortran
+Requires: datetime-fortran
 Cflags: -I"${includedir}"
 Libs: -L"${libdir}" -laccessom2


### PR DESCRIPTION
In order to successfully link `libaccessom2` I had to list the `datetime-fortran` dependency under `Requires`, not `Requires.private`. I can't say I understand why, but this seemed fix issues I was having with linking.

Also, with this PR we now set `libdir` from `CMAKE_INSTALL_LIBDIR`.

Also also, should `OASIS` packages be included in the `Requires` section? Things work for me without them included, but in my application I am also explicitly linking `OASIS`.