### PR TITLE
Build-CI: Specify correct branch (master) in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 jobs:
   pre-ci:
     name: Pre-CI

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 
-| GitHub CI | Travis CI | Jenkins Tests |
-|:----------------:|:----------------:|:------------------:|
-|[![GitHub Build Status](https://github.com/COSIMA/libaccessom2/workflows/CI/badge.svg)](https://github.com/COSIMA/libaccessom2/actions?query=workflow%3ACI)|[![Build Status](https://travis-ci.org/COSIMA/libaccessom2.svg?branch=master)](https://travis-ci.org/COSIMA/libaccessom2) |[![Test Status](https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=ACCESS-OM2/libaccessom2)](https://accessdev.nci.org.au/jenkins/job/ACCESS-OM2/job/libaccessom2/)|
+[![Build](https://github.com/ACCESS-NRI/libaccessom2/actions/workflows/ci.yml/badge.svg)](https://github.com/ACCESS-NRI/libaccessom2/actions/workflows/ci.yml)
 
 # libaccessom2
 


### PR DESCRIPTION
Apologies, only noticed this after merging

Also, replacing broken badges in README with one that works