### PR TITLE
Build-CI: update versions

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -3,7 +3,7 @@
   "gcc_compiler": "gcc@13.2.0",
   "oneapi_compiler": "oneapi@2025.2.0",
   "target": "x86_64",
-  "mom5_version": "git.2025.05.000=access-om2",
+  "mom5_version": "git.2025.08.000=access-om2",
   "cice5_version": "git.2025.03.001=access-om2",
   "oasis3_mct_version": "git.2025.03.001=access-om2",
   "netcdf_c_version": "4.9.2",
@@ -11,6 +11,6 @@
   "parallelio_version": "2.6.2",
   "openmpi_version": "5.0.5",
   "access_fms_version": "git.mom5-2025.05.000=mom5",
-  "access_generic_tracers_version": "git.2025.07.001=main",
-  "access_mocsy_version": "git.2025.07.002=gtracers"
+  "access_generic_tracers_version": "2025.07.002",
+  "access_mocsy_version": "2025.07.002"
 }


### PR DESCRIPTION
In https://github.com/ACCESS-NRI/spack-packages/pull/297, we added explicit versions for access-generic-tracers and access-mocsy. This PR updates the Build-CI to use:

- `mom5@git.2025.08.000=access-om2`
- `access-generic-tracers@2025.07.002`
- `access-mocsy@2025.07.002`